### PR TITLE
add rule: comma-dangle

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     "jasmine": true
   },
   "rules": {
+    "comma-dangle": [1, "only-multiline"],
     "dot-location": [1, "property"],
     "no-empty-character-class": 1,
     "no-underscore-dangle": 0,


### PR DESCRIPTION
默认情况下会对下面这种写法报错：
```javascript
const foo = {
     bar: "baz",
     qux: "quux",
 }
```

而多行的对象和数组在项目中基本都加了逗号，所以增加了规则：
`"comma-dangle": [1, "only-multiline"]`
表示多行时允许（但不强制）尾部逗号，单行时不允许。