### PR TITLE
add rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
     "rest-spread-spacing": [1, "never"],
     "dot-location": [1, "property"],
     "no-empty-character-class": 1,
+    "no-unexpected-multiline": 1,
     "no-dupe-class-members": 1,
     "no-underscore-dangle": 0,
     "no-use-before-define": 0,

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
     "semi": [1, "never"],
     "no-implied-eval": 1,
     "no-extra-bind": 1,
+    'require-await': 1,
     "valid-typeof": 1,
     "no-dupe-keys": 1,
     "no-labels": 1,


### PR DESCRIPTION
1. `no-unexpected-multiline`: 防止多行代码被（意外地）解析为连续的运算表达式。在采用 “句末不写分号” 风格的代码中比较容易出现这种情况：当第一行末尾没有分号，而第二行开头是 `(` 或 `[` 等字符时，第二行会视为紧接上一行代码的延续，这往往与预期不符
2. `require-await`: `async` 函数内需有 `await` 关键字